### PR TITLE
Time & date picker defaulting to London time

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -31,8 +31,10 @@ public partial class MainWindow : Window
             Dispatcher.Invoke(() => StatusProgress.Value = progress);
         };
 
-        StartTimePicker.Value = DateTime.Now;
-        DatePicker.SelectedDate = DateTime.Now;
+        TimeZoneInfo londonTimeZone = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+        DateTime londonTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, londonTimeZone);
+        StartTimePicker.Value = londonTime;
+        DatePicker.SelectedDate = londonTime;
     }
 
     private void Downloader_StatusUpdate(object sender, string e)


### PR DESCRIPTION
Fixes #2.

Not sure if this actually works when BST is being used, but I'm confident that it does. :)